### PR TITLE
#451 Implement `Optional` type for partial updates in network request…

### DIFF
--- a/composeApp/src/commonMain/kotlin/plus/vplan/app/di/appModule.kt
+++ b/composeApp/src/commonMain/kotlin/plus/vplan/app/di/appModule.kt
@@ -8,15 +8,29 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.content.TextContent
 import io.ktor.http.isSuccess
-import io.ktor.serialization.kotlinx.json.json
+import io.ktor.http.withCharset
+import io.ktor.serialization.ContentConverter
+import io.ktor.util.reflect.TypeInfo
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.charsets.Charset
+import io.ktor.utils.io.readRemaining
+import io.ktor.utils.io.readText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.serializer
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -135,6 +149,42 @@ import kotlin.time.Instant
 
 expect val platformModule: Module
 
+val appJson = Json {
+    ignoreUnknownKeys = true
+    classDiscriminator = "type"
+    encodeDefaults = true
+}
+
+val UNDEFINED_SENTINEL = JsonPrimitive("__undefined__")
+
+fun JsonElement.stripUndefined(): JsonElement = when (this) {
+    is JsonObject -> JsonObject(
+        entries
+            .associate { it.toPair() }
+            .filter { (_, v) -> v != UNDEFINED_SENTINEL }
+            .mapValues { (_, v) -> v.stripUndefined() }
+    )
+    is JsonArray -> JsonArray(map { it.stripUndefined() })
+    else -> this
+}
+
+class UndefinedStrippingConverter(private val json: Json) : ContentConverter {
+    override suspend fun serialize(contentType: ContentType, charset: Charset, typeInfo: TypeInfo, value: Any?): OutgoingContent? {
+        val serializer = json.serializersModule.serializer(typeInfo.kotlinType ?: return null)
+        val element = json.encodeToJsonElement(serializer, value ?: return null)
+        return TextContent(
+            json.encodeToString(element.stripUndefined()),
+            contentType.withCharset(charset)
+        )
+    }
+
+    override suspend fun deserialize(charset: Charset, typeInfo: TypeInfo, content: ByteReadChannel): Any? {
+        val serializer = json.serializersModule.serializer(typeInfo.kotlinType ?: return null)
+        val text = content.readRemaining().readText()
+        return json.decodeFromString(serializer, text)
+    }
+}
+
 val appModule = module(createdAtStart = true) {
     single<CoroutineScope> { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
 
@@ -142,11 +192,7 @@ val appModule = module(createdAtStart = true) {
         val appLogger = co.touchlab.kermit.Logger.withTag("Ktor Client")
         HttpClient {
             install(ContentNegotiation) {
-                json(Json {
-                    ignoreUnknownKeys = true
-                    classDiscriminator = "type"
-                    encodeDefaults = true
-                })
+                register(ContentType.Application.Json, UndefinedStrippingConverter(appJson))
             }
 
             install(HttpRequestRetry) {

--- a/core/data/src/commonMain/kotlin/plus/vplan/app/core/data/assessment/AssessmentRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/plus/vplan/app/core/data/assessment/AssessmentRepositoryImpl.kt
@@ -15,17 +15,18 @@ import plus.vplan.app.core.model.Alias
 import plus.vplan.app.core.model.AliasProvider
 import plus.vplan.app.core.model.AppEntity
 import plus.vplan.app.core.model.Assessment
-import plus.vplan.app.core.model.Optional
 import plus.vplan.app.core.model.Profile
 import plus.vplan.app.core.model.Response
 import plus.vplan.app.core.model.VppId
 import plus.vplan.app.core.model.VppSchoolAuthentication
+import plus.vplan.app.core.utils.Optional
 import plus.vplan.app.network.vpp.assessment.AssessmentApi
 import plus.vplan.app.network.vpp.assessment.AssessmentPatchRequest
 import plus.vplan.app.network.vpp.assessment.AssessmentPostRequest
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
+import plus.vplan.app.core.model.Optional as ModelOptional
 
 class AssessmentRepositoryImpl(
     private val assessmentDao: AssessmentDao,
@@ -190,10 +191,10 @@ class AssessmentRepositoryImpl(
 
     override suspend fun updateAssessmentMetadata(
         assessment: Assessment,
-        date: Optional<LocalDate>,
-        type: Optional<Assessment.Type>,
-        isPublic: Optional<Boolean>,
-        content: Optional<String>,
+        date: ModelOptional<LocalDate>,
+        type: ModelOptional<Assessment.Type>,
+        isPublic: ModelOptional<Boolean>,
+        content: ModelOptional<String>,
         profile: Profile.StudentProfile
     ) {
         val activeVppId = profile.vppId?.asActive()
@@ -206,10 +207,10 @@ class AssessmentRepositoryImpl(
                         activeVppId,
                         assessment.id,
                         AssessmentPatchRequest(
-                            type = if (type is Optional.Present) type.value.name else null,
-                            date = if (date is Optional.Present) date.value.toString() else null,
-                            isPublic = if (isPublic is Optional.Present) isPublic.value else null,
-                            content = if (content is Optional.Present) content.value else null
+                            type = if (type is ModelOptional.Present) Optional.Defined(type.value.name) else Optional.Undefined(),
+                            date = if (date is ModelOptional.Present) Optional.Defined(date.value.toString()) else Optional.Undefined(),
+                            isPublic = if (isPublic is ModelOptional.Present) Optional.Defined(isPublic.value) else Optional.Undefined(),
+                            content = if (content is ModelOptional.Present) Optional.Defined(content.value) else Optional.Undefined(),
                         )
                     )
                 } catch (e: Exception) {
@@ -220,16 +221,16 @@ class AssessmentRepositoryImpl(
         }
 
         // Update local database
-        if (date is Optional.Present) {
+        if (date is ModelOptional.Present) {
             assessmentDao.updateDate(assessment.id, date.value)
         }
-        if (type is Optional.Present) {
+        if (type is ModelOptional.Present) {
             assessmentDao.updateType(assessment.id, type.value.ordinal)
         }
-        if (isPublic is Optional.Present) {
+        if (isPublic is ModelOptional.Present) {
             assessmentDao.updateVisibility(assessment.id, isPublic.value)
         }
-        if (content is Optional.Present) {
+        if (content is ModelOptional.Present) {
             assessmentDao.updateContent(assessment.id, content.value)
         }
     }

--- a/core/data/src/commonMain/kotlin/plus/vplan/app/core/data/homework/HomeworkRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/plus/vplan/app/core/data/homework/HomeworkRepositoryImpl.kt
@@ -18,17 +18,18 @@ import plus.vplan.app.core.model.AliasProvider
 import plus.vplan.app.core.model.CacheState
 import plus.vplan.app.core.model.Group
 import plus.vplan.app.core.model.Homework
-import plus.vplan.app.core.model.Optional
 import plus.vplan.app.core.model.Profile
 import plus.vplan.app.core.model.Response
 import plus.vplan.app.core.model.SubjectInstance
 import plus.vplan.app.core.model.VppId
 import plus.vplan.app.core.model.getByProvider
+import plus.vplan.app.core.utils.Optional
 import plus.vplan.app.network.vpp.homework.HomeworkApi
 import plus.vplan.app.network.vpp.homework.HomeworkPatchRequest
 import plus.vplan.app.network.vpp.homework.HomeworkPostRequest
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
+import plus.vplan.app.core.model.Optional as ModelOptional
 
 class HomeworkRepositoryImpl(
     private val homeworkDao: HomeworkDao,
@@ -341,10 +342,10 @@ class HomeworkRepositoryImpl(
 
     override suspend fun updateHomeworkMetadata(
         homework: Homework,
-        dueTo: Optional<LocalDate>,
-        subjectInstance: Optional<SubjectInstance?>,
-        group: Optional<Group?>,
-        isPublic: Optional<Boolean>,
+        dueTo: ModelOptional<LocalDate>,
+        subjectInstance: ModelOptional<SubjectInstance?>,
+        group: ModelOptional<Group?>,
+        isPublic: ModelOptional<Boolean>,
         profile: Profile.StudentProfile
     ) {
         val activeVppId = profile.vppId?.asActive()
@@ -356,39 +357,39 @@ class HomeworkRepositoryImpl(
                     homework.id,
                     HomeworkPatchRequest(
                         subjectInstanceId = if (subjectInstance.isPresent()) 
-                            (subjectInstance as Optional.Present).value?.aliases?.getByProvider(AliasProvider.Vpp)?.value?.toIntOrNull()
-                        else null,
+                            Optional.Defined((subjectInstance as ModelOptional.Present).value?.aliases?.getByProvider(AliasProvider.Vpp)?.value?.toIntOrNull())
+                        else Optional.Undefined(),
                         groupId = if (group.isPresent())
-                            (group as Optional.Present).value?.aliases?.getByProvider(AliasProvider.Vpp)?.value?.toIntOrNull()
-                        else null,
+                            Optional.Defined((group as ModelOptional.Present).value?.aliases?.getByProvider(AliasProvider.Vpp)?.value?.toIntOrNull())
+                        else Optional.Undefined(),
                         dueTo = if (dueTo.isPresent())
-                            (dueTo as Optional.Present).value.toString()
-                        else null,
+                            Optional.Defined((dueTo as ModelOptional.Present).value.toString())
+                        else Optional.Undefined(),
                         isPublic = if (isPublic.isPresent())
-                            (isPublic as Optional.Present).value
-                        else null
+                            Optional.Defined((isPublic as ModelOptional.Present).value)
+                        else Optional.Undefined()
                     )
                 )
             }
         }
         
         // Update local database
-        if (dueTo is Optional.Present) {
+        if (dueTo is ModelOptional.Present) {
             homeworkDao.updateDueTo(homework.id, dueTo.value)
         }
-        if (subjectInstance is Optional.Present || group is Optional.Present) {
+        if (subjectInstance is ModelOptional.Present || group is ModelOptional.Present) {
             // Only update the fields that were provided
             val subjectInstanceId = when {
-                subjectInstance is Optional.Present -> subjectInstance.value?.id
+                subjectInstance is ModelOptional.Present -> subjectInstance.value?.id
                 else -> homework.subjectInstance?.id
             }
             val groupId = when {
-                group is Optional.Present -> group.value?.id
+                group is ModelOptional.Present -> group.value?.id
                 else -> homework.group?.id
             }
             homeworkDao.updateSubjectInstanceAndGroup(homework.id, subjectInstanceId, groupId)
         }
-        if (isPublic is Optional.Present) {
+        if (isPublic is ModelOptional.Present) {
             homeworkDao.updateVisibility(homework.id, isPublic.value)
         }
     }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
             // Project modules
             implementation(project(":core:database"))
             implementation(project(":core:model"))
+            implementation(project(":core:utils"))
 
             // KotlinX
             implementation(libs.kotlinx.serialization.json)

--- a/core/network/src/commonMain/kotlin/plus/vplan/app/network/vpp/assessment/AssessmentPatchRequest.kt
+++ b/core/network/src/commonMain/kotlin/plus/vplan/app/network/vpp/assessment/AssessmentPatchRequest.kt
@@ -1,12 +1,14 @@
 package plus.vplan.app.network.vpp.assessment
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import plus.vplan.app.core.utils.Optional
 
 @Serializable
 data class AssessmentPatchRequest(
-    @SerialName("type") val type: String? = null,
-    @SerialName("date") val date: String? = null,
-    @SerialName("is_public") val isPublic: Boolean? = null,
-    @SerialName("content") val content: String? = null
+    @EncodeDefault(EncodeDefault.Mode.NEVER) @SerialName("type") val type: Optional<String> = Optional.Undefined(),
+    @EncodeDefault(EncodeDefault.Mode.NEVER) @SerialName("date") val date: Optional<String> = Optional.Undefined(),
+    @EncodeDefault(EncodeDefault.Mode.NEVER) @SerialName("is_public") val isPublic: Optional<Boolean> = Optional.Undefined(),
+    @EncodeDefault(EncodeDefault.Mode.NEVER) @SerialName("content") val content: Optional<String> = Optional.Undefined(),
 )

--- a/core/network/src/commonMain/kotlin/plus/vplan/app/network/vpp/homework/HomeworkApi.kt
+++ b/core/network/src/commonMain/kotlin/plus/vplan/app/network/vpp/homework/HomeworkApi.kt
@@ -1,9 +1,11 @@
 package plus.vplan.app.network.vpp.homework
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import plus.vplan.app.core.model.VppId
 import plus.vplan.app.core.model.VppSchoolAuthentication
+import plus.vplan.app.core.utils.Optional
 
 interface HomeworkApi {
     suspend fun getHomeworkItems(
@@ -119,10 +121,10 @@ data class HomeworkPostResponseItem(
 
 @Serializable
 data class HomeworkPatchRequest(
-    @SerialName("subject_instance_id") val subjectInstanceId: Int? = null,
-    @SerialName("group_id") val groupId: Int? = null,
-    @SerialName("due_to") val dueTo: String? = null,
-    @SerialName("is_public") val isPublic: Boolean? = null,
+    @EncodeDefault(EncodeDefault.Mode.NEVER) @SerialName("subject_instance_id") val subjectInstanceId: Optional<Int?> = Optional.Undefined(),
+    @EncodeDefault(EncodeDefault.Mode.NEVER) @SerialName("group_id") val groupId: Optional<Int?> = Optional.Undefined(),
+    @EncodeDefault(EncodeDefault.Mode.NEVER) @SerialName("due_to") val dueTo: Optional<String> = Optional.Undefined(),
+    @EncodeDefault(EncodeDefault.Mode.NEVER) @SerialName("is_public") val isPublic: Optional<Boolean> = Optional.Undefined(),
 )
 
 @Serializable

--- a/core/utils/src/commonMain/kotlin/plus/vplan/app/core/utils/Optional.kt
+++ b/core/utils/src/commonMain/kotlin/plus/vplan/app/core/utils/Optional.kt
@@ -1,0 +1,50 @@
+@file:Suppress("unused")
+
+package plus.vplan.app.core.utils
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+@Serializable(with = OptionalSerializer::class)
+sealed class Optional<T> {
+    fun getOrNull(): T? = when (this) {
+        is Defined -> value
+        is Undefined -> null
+    }
+
+    fun getOrElse(default: T): T = getOrNull() ?: default
+
+    data object Undefined : Optional<Nothing>() {
+        @Suppress("UNCHECKED_CAST")
+        operator fun <T> invoke(): Optional<T> = this as Optional<T>
+    }
+    data class Defined<T>(val value: T) : Optional<T>()
+}
+
+@OptIn(ExperimentalContracts::class)
+fun <T> Optional<T>.isDefined(): Boolean {
+    contract {
+        returns(true) implies (this@isDefined is Optional.Defined<T>)
+    }
+    return this is Optional.Defined<T>
+}
+
+class OptionalSerializer<T>(private val serializer: KSerializer<T>) : KSerializer<Optional<T>> {
+    override val descriptor: SerialDescriptor = serializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: Optional<T>) {
+        when (value) {
+            is Optional.Defined -> encoder.encodeSerializableValue(serializer, value.value)
+            is Optional.Undefined -> {} // Do nothing if Undefined
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): Optional<T> {
+        return Optional.Defined(decoder.decodeSerializableValue(serializer))
+    }
+}


### PR DESCRIPTION
…s and refactor CI build process.

- Introduce `Optional` utility with a custom serializer to handle undefined values in JSON requests.
- Update `HomeworkPatchRequest` and `AssessmentPatchRequest` to use `Optional` types.
- Implement `UndefinedStrippingConverter` in Ktor to omit undefined fields from serialized JSON.
- Refactor iOS Fastlane configuration into modular lanes for different distribution channels.
- Simplify iOS version management by removing automatic `Version.xcconfig` generation in favor of static values.
- Update `HomeworkRepositoryImpl` and `AssessmentRepositoryImpl` to support the new `Optional` utility for metadata updates.