### PR TITLE
#455 Add feature to track and display the last plan update time

### DIFF
--- a/composeApp/src/commonMain/kotlin/plus/vplan/app/feature/home/ui/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/plus/vplan/app/feature/home/ui/HomeScreen.kt
@@ -62,9 +62,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
 import kotlinx.datetime.format.Padding
 import kotlinx.datetime.format.char
+import kotlinx.datetime.toInstant
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 import plus.vplan.app.core.model.Alias
@@ -86,6 +88,7 @@ import plus.vplan.app.feature.assessment.ui.components.create.NewAssessmentDrawe
 import plus.vplan.app.feature.home.ui.components.DayInfoCard
 import plus.vplan.app.feature.home.ui.components.FeedTitle
 import plus.vplan.app.feature.home.ui.components.Greeting
+import plus.vplan.app.feature.home.ui.components.LastUpdated
 import plus.vplan.app.feature.home.ui.components.QuickActions
 import plus.vplan.app.feature.homework.ui.components.NewHomeworkDrawer
 import plus.vplan.app.feature.main.ui.MainScreen
@@ -719,6 +722,15 @@ private fun HomeContent(
                                 }
                             }
                         }
+                    }
+                    if (state.lastPlanUpdate != null) item {
+                        LastUpdated(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp),
+                            currentTime = state.currentTime.toInstant(TimeZone.currentSystemDefault()),
+                            lastUpdated = state.lastPlanUpdate
+                        )
                     }
                     item bottomSpacer@{  }
                 }

--- a/composeApp/src/commonMain/kotlin/plus/vplan/app/feature/home/ui/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/plus/vplan/app/feature/home/ui/HomeViewModel.kt
@@ -47,6 +47,8 @@ import plus.vplan.app.feature.home.domain.usecase.GetNewsUseCase
 import plus.vplan.app.feature.sync.domain.usecase.sp24.UpdateHolidaysUseCase
 import plus.vplan.app.utils.sortedBySuspending
 import plus.vplan.lib.sp24.source.Authentication
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModel(
@@ -181,6 +183,18 @@ class HomeViewModel(
                     }
                 }
         }
+
+        viewModelScope.launch {
+            keyValueRepository.get(Keys.LAST_PLAN_UPDATE).collectLatest { lastUpdateTimestamp ->
+                if (lastUpdateTimestamp == null) {
+                    state.update { state -> state.copy(lastPlanUpdate = null) }
+                    return@collectLatest
+                }
+
+                val lastUpdate = Instant.fromEpochSeconds(lastUpdateTimestamp.toLong())
+                state.update { state -> state.copy(lastPlanUpdate = lastUpdate) }
+            }
+        }
     }
 
     private fun launchNews(profile: Profile) {
@@ -233,6 +247,7 @@ class HomeViewModel(
                                 allowNotification = false,
                                 providedClient = client
                             )
+                            keyValueRepository.set(Keys.LAST_PLAN_UPDATE, Clock.System.now().epochSeconds.toString())
                         }
                     } catch (e: Exception) {
                         e.printStackTrace()
@@ -256,7 +271,8 @@ data class HomeState(
     val hasInterpolatedLessonTimes: Boolean = false,
     val currentLessons: List<CurrentLesson> = emptyList(),
     val nextLessons: List<Lesson> = emptyList(),
-    val remainingLessons: Map<Int, List<Lesson>> = emptyMap()
+    val remainingLessons: Map<Int, List<Lesson>> = emptyMap(),
+    val lastPlanUpdate: Instant? = null,
 )
 
 sealed class HomeEvent {

--- a/composeApp/src/commonMain/kotlin/plus/vplan/app/feature/home/ui/components/LastUpdate.kt
+++ b/composeApp/src/commonMain/kotlin/plus/vplan/app/feature/home/ui/components/LastUpdate.kt
@@ -1,0 +1,72 @@
+package plus.vplan.app.feature.home.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.toLocalDateTime
+import plus.vplan.app.core.ui.theme.AppTheme
+import plus.vplan.app.core.utils.date.regularDateTimeFormat
+import plus.vplan.app.core.utils.date.untilRelativeText
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+@Composable
+fun LastUpdated(
+    modifier: Modifier = Modifier,
+    lastUpdated: Instant,
+    currentTime: Instant,
+) {
+    val lastUpdateMoreThanTwoHoursAgo = currentTime.epochSeconds - lastUpdated.epochSeconds > 2.hours.inWholeSeconds
+    Text(
+        modifier = modifier
+            .fillMaxWidth(),
+        text = buildString {
+            append("Letzte Aktualisierung: ")
+            if (lastUpdateMoreThanTwoHoursAgo) {
+                append(lastUpdated.toLocalDateTime(TimeZone.currentSystemDefault()).format(regularDateTimeFormat))
+            } else {
+                append(currentTime untilRelativeText lastUpdated)
+            }
+        },
+        color = MaterialTheme.colorScheme.secondary,
+        style = MaterialTheme.typography.bodySmall,
+        textAlign = TextAlign.Center,
+    )
+}
+
+@Preview
+@Composable
+private fun LastUpdatedPreview() {
+    val currentTime = Instant.fromEpochSeconds(1700000000)
+    AppTheme(dynamicColor = false) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            LastUpdated(
+                lastUpdated = currentTime - 1.hours,
+                currentTime = currentTime
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun LastUpdatedLongPreview() {
+    val currentTime = Instant.fromEpochSeconds(1700000000)
+    AppTheme(dynamicColor = false) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            LastUpdated(
+                lastUpdated = currentTime - 3.hours,
+                currentTime = currentTime
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/plus/vplan/app/feature/sync/domain/usecase/fullsync/FullSyncUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/plus/vplan/app/feature/sync/domain/usecase/fullsync/FullSyncUseCase.kt
@@ -250,6 +250,7 @@ class FullSyncUseCase(
                 cloudDataUpdate.join()
                 schoolDataUpdate.join()
 
+                keyValueRepository.set(Keys.LAST_PLAN_UPDATE, Clock.System.now().epochSeconds.toString())
                 logger.i { "FullSync done" }
             } finally {
                 isRunning = false

--- a/core/data/src/commonMain/kotlin/plus/vplan/app/core/data/KeyValueRepository.kt
+++ b/core/data/src/commonMain/kotlin/plus/vplan/app/core/data/KeyValueRepository.kt
@@ -34,6 +34,11 @@ object Keys {
     const val DEVELOPER_SETTINGS_DISABLE_AUTO_SYNC = "developer_settings_disable_auto_sync"
 
     /**
+     * Relevant for showing the user when the app fetched the last timetable and substitution plan
+     */
+    const val LAST_PLAN_UPDATE = "LAST_PLAN_UPDATE"
+
+    /**
      * If true, the calendar view will always use the list view instead of the default calendar view.
      * This view is also used if there are not enough lesson times.
      */

--- a/core/utils/src/commonMain/kotlin/plus/vplan/app/core/utils/date/format.kt
+++ b/core/utils/src/commonMain/kotlin/plus/vplan/app/core/utils/date/format.kt
@@ -1,6 +1,7 @@
 package plus.vplan.app.core.utils.date
 
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.format.Padding
 import kotlinx.datetime.format.char
 
@@ -24,4 +25,14 @@ val regularDateFormatWithoutYear = LocalDate.Format {
     day(padding = Padding.ZERO)
     char('.')
     monthNumber(Padding.ZERO)
+}
+
+val regularDateTimeFormat = LocalDateTime.Format {
+    day(padding = Padding.ZERO)
+    char('.')
+    monthNumber(Padding.ZERO)
+    chars(", ")
+    hour(Padding.ZERO)
+    char(':')
+    minute(Padding.ZERO)
 }

--- a/core/utils/src/commonMain/kotlin/plus/vplan/app/core/utils/date/untilRelativeText.kt
+++ b/core/utils/src/commonMain/kotlin/plus/vplan/app/core/utils/date/untilRelativeText.kt
@@ -2,6 +2,8 @@ package plus.vplan.app.core.utils.date
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.minus
+import kotlin.math.abs
+import kotlin.time.Instant
 
 infix fun LocalDate.untilRelativeText(other: LocalDate): String? {
     val days = (other - this).days
@@ -13,4 +15,37 @@ infix fun LocalDate.untilRelativeText(other: LocalDate): String? {
         2 -> "Übermorgen"
         else -> null
     }
+}
+
+const val SECONDS_PER_MINUTE = 60L
+const val SECONDS_PER_HOUR = 3600L
+const val SECONDS_PER_DAY = 86400L
+const val JUST_NOW_THRESHOLD = 30L
+infix fun Instant.untilRelativeText(other: Instant): String {
+    val seconds = (other - this).inWholeSeconds
+    val absSeconds = abs(seconds)
+    val isFuture = seconds > 0
+
+    val parts = mutableListOf<String>()
+
+    val days = absSeconds / SECONDS_PER_DAY
+    val hours = (absSeconds % SECONDS_PER_DAY) / SECONDS_PER_HOUR
+    val minutes = (absSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
+    val secs = absSeconds % SECONDS_PER_MINUTE
+
+    when {
+        absSeconds < JUST_NOW_THRESHOLD -> return "Gerade eben"
+        absSeconds < SECONDS_PER_DAY -> {
+            if (hours > 0) parts += "$hours ${if (hours == 1L) "Stunde" else "Stunden"}"
+            if (minutes > 0) parts += "$minutes ${if (minutes == 1L) "Minute" else "Minuten"}"
+            if (parts.isEmpty()) parts += "$secs ${if (secs == 1L) "Sekunde" else "Sekunden"}"
+        }
+        else -> {
+            if (days > 0) parts += "$days ${if (days == 1L) "Tag" else "Tagen"}"
+            if (hours > 0) parts += "$hours ${if (hours == 1L) "Stunde" else "Stunden"}"
+        }
+    }
+
+    val text = parts.joinToString(" und ")
+    return if (isFuture) "in $text" else "vor $text"
 }


### PR DESCRIPTION
- Add `LAST_PLAN_UPDATE` key to `KeyValueRepository`
- Update timestamp in `FullSyncUseCase` and `HomeViewModel` after successful synchronization
- Implement `untilRelativeText` for `Instant` to provide human-readable relative time strings
- Add `LastUpdated` component to `HomeScreen` to show when the timetable was last refreshed
- Add `regularDateTimeFormat` for absolute timestamp formatting